### PR TITLE
Align authentication routing and document API configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@ This is an [Expo](https://expo.dev) project created with [`create-expo-app`](htt
    npm install
    ```
 
-2. Start the app
+2. Configure the environment variables (see the section below).
+
+3. Start the app
 
    ```bash
-    npx expo start
+   npx expo start
    ```
 
 In the output, you'll find options to open the app in a
@@ -24,6 +26,31 @@ In the output, you'll find options to open the app in a
 - [Expo Go](https://expo.dev/go), a limited sandbox for trying out app development with Expo
 
 You can start developing by editing the files inside the **app** directory. This project uses [file-based routing](https://docs.expo.dev/router/introduction).
+
+## Environment configuration
+
+The app reads its backend URLs from a `.env` file. An example is provided in `.env.example`:
+
+```env
+EXPO_PUBLIC_API_URL=http://localhost:3000
+```
+
+To configure the project:
+
+1. Copy the example file:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+2. Update `EXPO_PUBLIC_API_URL` to point to the desired backend.
+   - When running the backend locally with Docker on the same machine, keep `http://localhost:3000` or adjust the port to match the container mapping.
+   - When the backend runs on another host or in production, replace the value with the public URL (for example, `https://api.example.com`).
+   - Ensure that the configured backend exposes the authentication endpoints used by the mobile app: `POST /auth/login` and `POST /auth/register`.
+
+3. Restart Expo after changing the `.env` file so the new value is loaded.
+
+Any developer can now switch between environments by editing a single variable, allowing the mobile app to communicate with local, staging, or production APIs.
 
 ## Get a fresh project
 

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -19,6 +19,7 @@ export default function LoginScreen() {
     try {
       setLoading(true);
       await signIn(email, password);
+      router.replace('/');
     } catch (err) {
       Alert.alert('Erro', 'Credenciais inválidas ou erro ao conectar.');
     } finally {

--- a/app/(auth)/register.tsx
+++ b/app/(auth)/register.tsx
@@ -19,6 +19,7 @@ export default function RegisterScreen() {
     try {
       setLoading(true);
       await signUp(email, password);
+      router.replace('/');
     } catch (err) {
       Alert.alert('Erro', 'Erro ao cadastrar usuário.');
     } finally {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -21,15 +21,18 @@ function LayoutInner() {
 
   useEffect(() => {
     if (!loading) {
-      if (!userToken && pathname !== '/login') {
+      const isAuthRoute =
+        pathname.startsWith('/(auth)') || pathname === '/login' || pathname === '/register';
+
+      if (!userToken && !isAuthRoute) {
         router.replace('/login');
       }
 
-      if (userToken && pathname.startsWith('/(auth)')) {
+      if (userToken && isAuthRoute) {
         router.replace('/');
       }
     }
-  }, [loading, userToken]);
+  }, [loading, userToken, pathname]);
 
   if (loading) {
     return (


### PR DESCRIPTION
## Summary
- update the root layout to consistently detect auth routes and keep protected screens behind authentication
- redirect users to the home screen after signing in or signing up
- document how to configure `EXPO_PUBLIC_API_URL` for different backend environments

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6904b78183a8832798e15311cd48d401