### PR TITLE
Fix auth token usage in layout

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -16,7 +16,7 @@ export default function Layout() {
 }
 
 function LayoutInner() {
-  const { accessToken, loading } = useAuth();
+  const { userToken, loading } = useAuth();
   const pathname = usePathname();
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- read the auth token from the context using the correct property
- prevent runtime ReferenceError when redirecting based on authentication state

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6908e1c6b85c8327b98153d5f4152fff