### PR TITLE
Fix item fetching and tab configuration

### DIFF
--- a/app/(protected)/_layout.tsx
+++ b/app/(protected)/_layout.tsx
@@ -6,10 +6,10 @@ export default function ProtectedTabsLayout() {
     <Tabs
       screenOptions={{
         headerShown: false,
-    tabBarActiveTintColor: '#FFFFFF',
-    tabBarStyle: {
-      backgroundColor: '#1B5E20',
-    },
+        tabBarActiveTintColor: '#FFFFFF',
+        tabBarStyle: {
+          backgroundColor: '#1B5E20',
+        },
       }}
     >
       <Tabs.Screen
@@ -26,14 +26,14 @@ export default function ProtectedTabsLayout() {
         options={{
           title: 'Criar Item',
           tabBarIcon: ({ color, size }) => (
-            <MaterialIcons name="house" color={color} size={size} />
+            <MaterialIcons name="add-circle-outline" color={color} size={size} />
           ),
         }}
       />
       <Tabs.Screen
         name="items"
         options={{
-          title: 'Item',
+          title: 'Meus Itens',
           tabBarIcon: ({ color, size }) => (
             <MaterialIcons name="category" color={color} size={size} />
           ),
@@ -48,7 +48,7 @@ export default function ProtectedTabsLayout() {
           ),
         }}
       />
-        <Tabs.Screen
+      <Tabs.Screen
         name="item/create-item"
         options={{
           href: null, // impede que apareça na tabbar

--- a/app/(protected)/home.tsx
+++ b/app/(protected)/home.tsx
@@ -1,3 +1,3 @@
-import ExploreScreen from '@/screens/HomeScreen';
+import CreateItemScreen from '@/screens/CreateItemScreen';
 
-export default ExploreScreen;
+export default CreateItemScreen;

--- a/app/(protected)/item/create-item.tsx
+++ b/app/(protected)/item/create-item.tsx
@@ -1,3 +1,3 @@
-import ItemsScreen from '@/screens/CreateItemScreen';
+import CreateItemScreen from '@/screens/CreateItemScreen';
 
-export default ItemsScreen;
+export default CreateItemScreen;

--- a/auth/AuthContext.tsx
+++ b/auth/AuthContext.tsx
@@ -90,7 +90,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const signIn = async (email: string, password: string) => {
-    const data = await auth.login(email, password);
+    const data = await authService.login(email, password);
     const token = data?.token ?? null;
     const userData = (data?.user as User | null) ?? null;
 
@@ -102,11 +102,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   };
 
   const signUp = async (email: string, password: string) => {
-    await auth.register(email, password);
+    await authService.register(email, password);
   };
 
   const signOut = async () => {
-    await auth.logout();
+    await authService.logout();
     setUserToken(null);
     setUser(null);
     await persistToken(null);

--- a/components/Map.jsx
+++ b/components/Map.jsx
@@ -1,13 +1,16 @@
 import React, { useEffect, useState } from "react";
-import { View } from "react-native";
+import { View, StyleSheet } from "react-native";
 import MapView, { Marker } from "react-native-maps";
 import { requestForegroundPermissionsAsync, getCurrentPositionAsync } from "expo-location";
+import { Portal, Modal, Text, Button } from "react-native-paper";
+
 import { useAuth } from "@/auth/AuthContext";
 import { getItems } from "@/services/itemService";
 
 const Map = () => {
   const [location, setLocation] = useState(null);
   const [markers, setMarkers] = useState([]);
+  const [showNoItemsModal, setShowNoItemsModal] = useState(false);
   const { userToken } = useAuth();
 
   async function requestLocationPermission() {
@@ -21,7 +24,7 @@ const Map = () => {
   useEffect(() => {
     requestLocationPermission();
   }, []);
-    
+
   useEffect(() => {
     if (!location || !userToken) {
       return;
@@ -59,6 +62,7 @@ const Map = () => {
           .filter(Boolean);
 
         setMarkers(formattedMarkers);
+        setShowNoItemsModal(formattedMarkers.length === 0);
       } catch (error) {
         console.error("Erro ao carregar itens no mapa:", error);
       }
@@ -70,9 +74,24 @@ const Map = () => {
       isSubscribed = false;
     };
   }, [location, userToken]);
-  
+
   return (
     <View style={{ flex: 1 }}>
+      <Portal>
+        <Modal
+          visible={showNoItemsModal}
+          onDismiss={() => setShowNoItemsModal(false)}
+          contentContainerStyle={styles.modalContainer}
+        >
+          <Text style={styles.modalTitle}>Nenhum item por perto</Text>
+          <Text style={styles.modalDescription}>
+            Voltaremos a avisar quando itens estiverem disponíveis próximos a você.
+          </Text>
+          <Button mode="contained" onPress={() => setShowNoItemsModal(false)} style={styles.modalButton}>
+            Entendi
+          </Button>
+        </Modal>
+      </Portal>
       {location && (
         <MapView
           style={{ flex: 1 }}
@@ -91,7 +110,6 @@ const Map = () => {
             title="Você está aqui"
             description="Sua localização atual"
           />
-          {/* Markers para os itens próximos */}
           {markers.map((marker) => (
             <Marker
               key={marker.id}
@@ -104,10 +122,33 @@ const Map = () => {
             />
           ))}
         </MapView>
-
       )}
     </View>
   );
 };
+
+const styles = StyleSheet.create({
+  modalContainer: {
+    backgroundColor: "white",
+    marginHorizontal: 24,
+    borderRadius: 16,
+    padding: 24,
+    alignItems: "center",
+    gap: 16,
+  },
+  modalTitle: {
+    fontSize: 18,
+    fontWeight: "bold",
+    textAlign: "center",
+  },
+  modalDescription: {
+    fontSize: 14,
+    textAlign: "center",
+    color: "#555",
+  },
+  modalButton: {
+    alignSelf: "stretch",
+  },
+});
 
 export default Map;

--- a/screens/CreateItemScreen.jsx
+++ b/screens/CreateItemScreen.jsx
@@ -7,9 +7,11 @@ import { useRouter } from 'expo-router';
 import baseStyles from '@/styles/baseStyles';
 import styles from '@/styles/styles';
 import { createItem } from '@/services/itemService';
+import { useAuth } from '@/auth/AuthContext';
 
 const CreateItemScreen = () => {
   const router = useRouter();
+  const { userToken } = useAuth();
 
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
@@ -36,7 +38,7 @@ const CreateItemScreen = () => {
       return;
     }
 
-    if (!accessToken) {
+    if (!userToken) {
       Alert.alert('Erro', 'Sessão expirada. Faça login novamente.');
       router.replace('/login');
       return;
@@ -55,7 +57,7 @@ const CreateItemScreen = () => {
         ],
       };
 
-      await createItem(payload);
+      await createItem(payload, userToken);
       Alert.alert('Sucesso', 'Item criado com sucesso!');
       router.replace('/');
     } catch (err) {
@@ -71,8 +73,21 @@ const CreateItemScreen = () => {
         <Text style={styles.formTitle}>Criar novo item</Text>
 
         <View style={styles.formFields}>
-          <TextInput label="Título" value={title} onChangeText={setTitle} mode="outlined" style={styles.textInput} />
-          <TextInput label="Descrição" value={description} onChangeText={setDescription} multiline mode="outlined" style={styles.textInput} />
+          <TextInput
+            label="Título"
+            value={title}
+            onChangeText={setTitle}
+            mode="outlined"
+            style={styles.textInput}
+          />
+          <TextInput
+            label="Descrição"
+            value={description}
+            onChangeText={setDescription}
+            multiline
+            mode="outlined"
+            style={styles.textInput}
+          />
           <TextInput label="Latitude" value={lat} disabled mode="outlined" style={styles.textInput} />
           <TextInput label="Longitude" value={lng} disabled mode="outlined" style={styles.textInput} />
         </View>

--- a/screens/ItemsScreen.jsx
+++ b/screens/ItemsScreen.jsx
@@ -7,24 +7,20 @@ import { FAB } from "react-native-paper";
 import ItemsList from "@/components/ItemsList";
 import { router } from "expo-router";
 import { getItems } from "@/services/itemService";
+import { useAuth } from "@/auth/AuthContext";
 
 const ItemsScreen = () => {
   const [items, setItems] = useState([]);
-  const { accessToken } = useAuth();
+  const { userToken } = useAuth();
 
   useEffect(() => {
     const fetchItems = async () => {
-      if (!accessToken) {
+      if (!userToken) {
         return;
       }
 
       try {
-        if (!userToken) {
-          setItems([]);
-          return;
-        }
-
-        const data = await getItems();
+        const data = await getItems(userToken);
         setItems(Array.isArray(data) ? data : []);
       } catch (err) {
         console.error("Erro ao buscar itens:", err);
@@ -32,21 +28,20 @@ const ItemsScreen = () => {
     };
 
     fetchItems();
-  }, [accessToken]);
+  }, [userToken]);
 
   return (
     <SafeAreaView style={[baseStyles.container, styles.scrollContainer]}>
-      <ScrollView contentContainerStyle={[styles.mainContent, { paddingVertical: 24 }]}>
+      <ScrollView contentContainerStyle={[styles.mainContent, { paddingVertical: 24 }]}> 
         <Text style={styles.formTitle}>Meus Itens</Text>
         <ItemsList items={items || []} />
       </ScrollView>
       <FAB
         style={localStyles.fab}
         icon="plus"
+        label="Criar Item"
         onPress={() => router.push("/item/create-item")}
-      >
-        Create Item
-      </FAB>
+      />
     </SafeAreaView>
   );
 };

--- a/services/itemService.ts
+++ b/services/itemService.ts
@@ -5,14 +5,23 @@ export interface CreateItemPayload {
   description: string;
   lat: number;
   lng: number;
+  images?: string[];
 }
 
-export async function createItem(payload: any) {
+function buildAuthHeaders(token?: string) {
+  if (!token) {
+    return {};
+  }
+
+  return {
+    Authorization: `Bearer ${token}`,
+  };
+}
+
+export async function createItem(payload: CreateItemPayload, token?: string) {
   try {
-    const response = await axios.post(`${API_URL}/v1/items`, payload, {
-      headers: {
-        'Content-Type': 'application/json',
-      },
+    const response = await apiClient.post('/v1/items', payload, {
+      headers: buildAuthHeaders(token),
     });
 
     return response.data?.data ?? response.data;
@@ -21,9 +30,12 @@ export async function createItem(payload: any) {
     throw new Error('Erro ao criar item');
   }
 }
-export async function getItems() {
+
+export async function getItems(token?: string) {
   try {
-    const response = await axios.get(`${API_URL}/v1/items`);
+    const response = await apiClient.get('/v1/items', {
+      headers: buildAuthHeaders(token),
+    });
     return response.data?.data ?? [];
   } catch (error: any) {
     console.error('Erro ao listar itens:', error?.response?.data || error.message);


### PR DESCRIPTION
## Summary
- fix the item service to use the shared API client with authorization support
- update item-related screens to consume AuthContext tokens and adjust the create item flow
- add a modal when no map items are nearby and correct bottom tab destinations and labels

## Testing
- npm run lint *(fails: ESLint is not configured for this project)*

------
https://chatgpt.com/codex/tasks/task_e_6908e30a264c8327b387b17ec66ae27a