### PR TITLE
Fix navigation routes after authentication

### DIFF
--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -74,7 +74,7 @@ export default function LoginScreen() {
               </Button>
             </View>
 
-            <TouchableOpacity onPress={() => router.push('/(auth)/register')}>
+            <TouchableOpacity onPress={() => router.push('/register')}>
               <Text style={styles.menuText}>Ainda não tem conta? Cadastre-se</Text>
             </TouchableOpacity>
           </MotiView>

--- a/app/(auth)/register.tsx
+++ b/app/(auth)/register.tsx
@@ -86,7 +86,7 @@ export default function RegisterScreen() {
               </Button>
             </View>
 
-            <TouchableOpacity onPress={() => router.replace('/(auth)/login')}>
+            <TouchableOpacity onPress={() => router.replace('/login')}>
               <Text style={styles.menuText}>Já tem conta? Entrar</Text>
             </TouchableOpacity>
           </MotiView>

--- a/app/(protected)/home.tsx
+++ b/app/(protected)/home.tsx
@@ -18,7 +18,7 @@ export default function CreateItemHomeScreen() {
         </Text>
         <TouchableOpacity
           style={localStyles.button}
-          onPress={() => router.push('/(protected)/item/create-item')}
+          onPress={() => router.push('/item/create-item')}
         >
           <Text style={localStyles.buttonText}>Começar</Text>
         </TouchableOpacity>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -22,16 +22,17 @@ function LayoutInner() {
 
   useEffect(() => {
     if (loading || redirectingRef.current) return;
-    
-    const isAuthRoute = pathname.startsWith('/(auth)') || pathname === '/login' || pathname === '/register';
-    const isProtectedRoute = pathname.startsWith('/(protected)');
+
+    const isAuthRoute = pathname === '/login' || pathname === '/register';
 
     // Se não está autenticado e não está em rota de auth, redireciona para login
     if (!userToken && !isAuthRoute) {
-      if (pathname !== '/(auth)/login') {
+      if (pathname !== '/login') {
         redirectingRef.current = true;
-        router.replace('/(auth)/login');
-        setTimeout(() => { redirectingRef.current = false; }, 500);
+        router.replace('/login');
+        setTimeout(() => {
+          redirectingRef.current = false;
+        }, 500);
       }
       return;
     }
@@ -39,16 +40,10 @@ function LayoutInner() {
     // Se está autenticado e está em rota de auth, redireciona para explorar
     if (userToken && isAuthRoute) {
       redirectingRef.current = true;
-      router.replace('/(protected)/index');
-      setTimeout(() => { redirectingRef.current = false; }, 500);
-      return;
-    }
-
-    // Se está autenticado e está na rota raiz, redireciona para explorar
-    if (userToken && pathname === '/') {
-      redirectingRef.current = true;
-      router.replace('/(protected)/index');
-      setTimeout(() => { redirectingRef.current = false; }, 500);
+      router.replace('/');
+      setTimeout(() => {
+        redirectingRef.current = false;
+      }, 500);
       return;
     }
   }, [loading, userToken, pathname]);

--- a/auth/AuthContext.tsx
+++ b/auth/AuthContext.tsx
@@ -139,7 +139,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     await persistToken(null);
     await persistUser(null);
     // Redirecionar para login após logout
-    router.replace('/(auth)/login');
+    router.replace('/login');
   };
 
   const updateUser = async (updates: Partial<User>) => {

--- a/screens/CreateItemScreen.jsx
+++ b/screens/CreateItemScreen.jsx
@@ -40,7 +40,7 @@ const CreateItemScreen = () => {
 
     if (!userToken) {
       Alert.alert('Erro', 'Sessão expirada. Faça login novamente.');
-      router.replace('/(auth)/login');
+      router.replace('/login');
       return;
     }
 
@@ -59,7 +59,7 @@ const CreateItemScreen = () => {
 
       await createItem(payload, userToken);
       Alert.alert('Sucesso', 'Item criado com sucesso!');
-      router.replace('/(protected)/items');
+      router.replace('/items');
     } catch (err) {
       Alert.alert('Erro', 'Falha ao criar item.');
     } finally {

--- a/screens/ItemsScreen.jsx
+++ b/screens/ItemsScreen.jsx
@@ -41,7 +41,7 @@ const ItemsScreen = () => {
         style={localStyles.fab}
         icon="plus"
         label="Criar Item"
-        onPress={() => router.push("/(protected)/item/create-item")}
+        onPress={() => router.push("/item/create-item")}
       />
     </SafeAreaView>
   );


### PR DESCRIPTION
## Summary
- update the root layout redirects to target Expo Router paths without route groups
- align navigation calls in auth, item creation, and items screens with the generated paths

## Testing
- npm run lint *(fails: ESLint is not configured for this project)*

------
https://chatgpt.com/codex/tasks/task_e_69092812456083279b66c5d558f229b6