### PR TITLE
Improve item creation workflow and listings

### DIFF
--- a/components/ItemsList.jsx
+++ b/components/ItemsList.jsx
@@ -1,17 +1,89 @@
 // /components/ItemsList.jsx
 import React from "react";
 import { View, StyleSheet } from "react-native";
-import { Card, Title, Paragraph } from "react-native-paper";
+import { Card, Title, Paragraph, Chip, Divider } from "react-native-paper";
+
+const formatCondition = (value) => {
+  if (!value) return null;
+
+  const normalized = String(value).toUpperCase();
+  switch (normalized) {
+    case "NEW":
+      return "Novo";
+    case "LIKE_NEW":
+      return "Seminovo";
+    case "USED":
+      return "Usado";
+    default:
+      return value;
+  }
+};
+
+const formatDateTime = (value) => {
+  if (!value) return null;
+
+  try {
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return value;
+    }
+
+    return date.toLocaleString();
+  } catch (error) {
+    return value;
+  }
+};
 
 const ItemsList = ({ items }) => {
   return (
     <View style={styles.container}>
       {items.map((item) => (
         <Card key={item.id} style={styles.card}>
+          {item?.images?.length ? (
+            <Card.Cover source={{ uri: item.images[0] }} style={styles.cover} />
+          ) : null}
           <Card.Content>
             <Title>{item.title}</Title>
+            {item.category ? (
+              <Chip icon="tag" style={styles.chip} compact>
+                {item.category}
+              </Chip>
+            ) : null}
             <Paragraph>{item.description}</Paragraph>
+            <View style={styles.metaRow}>
+              {item.condition ? (
+                <Chip icon="information-outline" style={styles.metaChip} compact>
+                  {formatCondition(item.condition)}
+                </Chip>
+              ) : null}
+              {item.status ? (
+                <Chip icon="check-circle" style={styles.metaChip} compact>
+                  {item.status}
+                </Chip>
+              ) : null}
+            </View>
+            <View style={styles.metaColumn}>
+              {item.owner?.name ? (
+                <Paragraph style={styles.metaText}>Doador: {item.owner.name}</Paragraph>
+              ) : null}
+              {item.owner?.email ? (
+                <Paragraph style={styles.metaText}>Contato: {item.owner.email}</Paragraph>
+              ) : null}
+              {item.lat !== undefined && item.lat !== null && item.lng !== undefined && item.lng !== null ? (
+                <Paragraph style={styles.metaText}>
+                  Localização: {typeof item.lat === 'number' ? item.lat.toFixed(4) : item.lat},{' '}
+                  {typeof item.lng === 'number' ? item.lng.toFixed(4) : item.lng}
+                </Paragraph>
+              ) : null}
+              {item.createdAt ? (
+                <Paragraph style={styles.metaText}>Criado em: {formatDateTime(item.createdAt)}</Paragraph>
+              ) : null}
+              {item.updatedAt ? (
+                <Paragraph style={styles.metaText}>Atualizado em: {formatDateTime(item.updatedAt)}</Paragraph>
+              ) : null}
+            </View>
           </Card.Content>
+          <Divider />
         </Card>
       ))}
     </View>
@@ -29,6 +101,30 @@ const styles = StyleSheet.create({
     elevation: 2,
     paddingHorizontal: 4,
     paddingVertical: 8,
+  },
+  cover: {
+    borderTopLeftRadius: 8,
+    borderTopRightRadius: 8,
+  },
+  metaRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+    marginTop: 12,
+  },
+  metaColumn: {
+    marginTop: 12,
+    gap: 4,
+  },
+  metaText: {
+    color: "#546E7A",
+  },
+  chip: {
+    alignSelf: "flex-start",
+    marginTop: 8,
+  },
+  metaChip: {
+    marginRight: 4,
   },
 });
 

--- a/screens/ItemsScreen.jsx
+++ b/screens/ItemsScreen.jsx
@@ -35,7 +35,13 @@ const ItemsScreen = () => {
     <SafeAreaView style={[baseStyles.container, styles.scrollContainer]}>
       <ScrollView contentContainerStyle={[styles.mainContent, { paddingVertical: 24 }]}> 
         <Text style={styles.formTitle}>Meus Itens</Text>
-        <ItemsList items={items || []} />
+        {items && items.length > 0 ? (
+          <ItemsList items={items} />
+        ) : (
+          <Text style={styles.menuText}>
+            Você ainda não cadastrou itens. Use o botão abaixo para criar o seu primeiro anúncio.
+          </Text>
+        )}
       </ScrollView>
       <FAB
         style={localStyles.fab}


### PR DESCRIPTION
## Summary
- add category and condition selectors to the create item screen along with a payload preview
- ensure create item requests always send placeholder images and include category/condition data
- enhance the user items list to show API response details and gracefully fall back when /items/mine is unavailable

## Testing
- npm run lint *(fails: ESLint is not configured for this project)*

------
https://chatgpt.com/codex/tasks/task_e_69092a54ac908327ba856bfd36829768