### PR TITLE
Handle unauthorized responses by redirecting to login

### DIFF
--- a/auth/AuthContext.tsx
+++ b/auth/AuthContext.tsx
@@ -8,6 +8,7 @@ import React, {
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { router } from 'expo-router';
 import * as authService from './authService';
+import { setUnauthorizedHandler } from '@/services/apiClient';
 
 type User = {
   id?: string;
@@ -87,6 +88,22 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     };
 
     loadSession();
+  }, []);
+
+  useEffect(() => {
+    const handleUnauthorized = async () => {
+      setUserToken(null);
+      setUser(null);
+      await persistToken(null);
+      await persistUser(null);
+      router.replace('/login');
+    };
+
+    setUnauthorizedHandler(handleUnauthorized);
+
+    return () => {
+      setUnauthorizedHandler(null);
+    };
   }, []);
 
   const signIn = async (email: string, password: string) => {

--- a/services/apiClient.ts
+++ b/services/apiClient.ts
@@ -1,5 +1,68 @@
-import axios from 'axios';
+import axios, { AxiosError, InternalAxiosRequestConfig } from 'axios';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { getApiBaseUrl } from './config';
+
+type UnauthorizedHandler = () => void | Promise<void>;
+
+let unauthorizedHandler: UnauthorizedHandler | null = null;
+let isRedirecting = false;
+
+export function setUnauthorizedHandler(handler: UnauthorizedHandler | null) {
+  unauthorizedHandler = handler;
+}
+
+async function attachToken(
+  config: InternalAxiosRequestConfig,
+): Promise<InternalAxiosRequestConfig> {
+  try {
+    const storedToken = await AsyncStorage.getItem('token');
+
+    if (storedToken) {
+      if (config.headers) {
+        const headers = config.headers as any;
+        const hasSet = typeof headers.set === 'function';
+
+        if (hasSet) {
+          const currentAuthorization = headers.get?.('Authorization') ?? headers.Authorization;
+          if (!currentAuthorization) {
+            headers.set('Authorization', `Bearer ${storedToken}`);
+          }
+        } else if (!headers.Authorization) {
+          headers.Authorization = `Bearer ${storedToken}`;
+        }
+      } else {
+        config.headers = { Authorization: `Bearer ${storedToken}` };
+      }
+    }
+  } catch (error) {
+    console.warn('Não foi possível anexar o token ao header Authorization:', error);
+  }
+
+  return config;
+}
+
+async function handleUnauthorized(error: AxiosError) {
+  if (error.response?.status !== 401) {
+    throw error;
+  }
+
+  try {
+    await AsyncStorage.multiRemove(['token', 'refreshToken', 'user']);
+  } catch (storageError) {
+    console.warn('Erro ao limpar dados de autenticação:', storageError);
+  }
+
+  if (!isRedirecting && unauthorizedHandler) {
+    isRedirecting = true;
+    try {
+      await unauthorizedHandler();
+    } finally {
+      isRedirecting = false;
+    }
+  }
+
+  throw error;
+}
 
 const apiClient = axios.create({
   baseURL: getApiBaseUrl(),
@@ -7,5 +70,18 @@ const apiClient = axios.create({
     'Content-Type': 'application/json',
   },
 });
+
+apiClient.interceptors.request.use(attachToken);
+
+apiClient.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    if (error instanceof AxiosError) {
+      return handleUnauthorized(error);
+    }
+
+    throw error;
+  },
+);
 
 export default apiClient;


### PR DESCRIPTION
## Summary
- add axios interceptors to automatically attach the saved JWT and clear auth state when a request is rejected with 401
- expose an unauthorized handler hook so the auth context can reset the session and navigate back to the login screen

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69093e02b0f883278aecd83764fcc7eb