### PR TITLE
feat: fetch categories from api

### DIFF
--- a/app/(protected)/_layout.tsx
+++ b/app/(protected)/_layout.tsx
@@ -33,10 +33,7 @@ export default function ProtectedTabsLayout() {
       <Tabs.Screen
         name="items"
         options={{
-          title: 'Meus Itens',
-          tabBarIcon: ({ color, size }) => (
-            <MaterialIcons name="category" color={color} size={size} />
-          ),
+          href: null,
         }}
       />
       <Tabs.Screen

--- a/components/ItemsList.jsx
+++ b/components/ItemsList.jsx
@@ -44,11 +44,23 @@ const ItemsList = ({ items }) => {
           ) : null}
           <Card.Content>
             <Title>{item.title}</Title>
-            {item.category ? (
-              <Chip icon="tag" style={styles.chip} compact>
-                {item.category}
-              </Chip>
-            ) : null}
+            {(() => {
+              const categoryName =
+                typeof item.category === 'string'
+                  ? item.category
+                  : item.category && typeof item.category === 'object'
+                    ? item.category.name
+                    : null;
+              if (!categoryName) {
+                return null;
+              }
+
+              return (
+                <Chip icon="tag" style={styles.chip} compact>
+                  {categoryName}
+                </Chip>
+              );
+            })()}
             <Paragraph>{item.description}</Paragraph>
             <View style={styles.metaRow}>
               {item.condition ? (

--- a/screens/ProductDetailScreen.tsx
+++ b/screens/ProductDetailScreen.tsx
@@ -32,7 +32,15 @@ interface ItemDetail {
   images?: string[];
   condition?: string;
   status?: string;
-  category?: string | null;
+  categoryId?: string | null;
+  category?:
+    | string
+    | {
+        id?: string;
+        name?: string;
+        description?: string | null;
+      }
+    | null;
   lat?: number | string | null;
   lng?: number | string | null;
   owner?: {
@@ -111,6 +119,21 @@ const ProductDetailScreen: React.FC = () => {
 
   const coverImage = item?.images?.[0] || FALLBACK_ITEM_IMAGE;
   const canTrade = Boolean(item?.owner?.email);
+  const categoryLabel = useMemo(() => {
+    if (!item?.category) {
+      return null;
+    }
+
+    if (typeof item.category === "string") {
+      return item.category;
+    }
+
+    if (typeof item.category === "object") {
+      return item.category?.name ?? null;
+    }
+
+    return null;
+  }, [item?.category]);
 
   const handleGoBack = useCallback(() => {
     router.back();
@@ -203,9 +226,9 @@ const ProductDetailScreen: React.FC = () => {
                 {item.status}
               </Chip>
             ) : null}
-            {item.category ? (
+            {categoryLabel ? (
               <Chip icon="tag" style={localStyles.chip} textStyle={localStyles.chipText}>
-                {item.category}
+                {categoryLabel}
               </Chip>
             ) : null}
           </View>

--- a/services/categoryService.ts
+++ b/services/categoryService.ts
@@ -1,0 +1,86 @@
+import apiClient from './apiClient';
+
+export interface Category {
+  id: string;
+  name: string;
+  description?: string | null;
+  createdAt?: string | null;
+  updatedAt?: string | null;
+}
+
+export interface CreateCategoryPayload {
+  name: string;
+  description?: string;
+}
+
+function buildAuthHeaders(token?: string) {
+  if (!token) {
+    return {};
+  }
+
+  return {
+    Authorization: `Bearer ${token}`,
+  };
+}
+
+function normalizeCategory(raw: any): Category | null {
+  if (!raw) {
+    return null;
+  }
+
+  const id = raw.id ?? raw._id ?? raw.uuid ?? raw.slug;
+  const name = raw.name ?? raw.title ?? raw.label;
+
+  if (!id || !name) {
+    return null;
+  }
+
+  return {
+    id: String(id),
+    name: String(name),
+    description: raw.description ?? null,
+    createdAt: raw.createdAt ?? null,
+    updatedAt: raw.updatedAt ?? null,
+  };
+}
+
+export async function getCategories(): Promise<Category[]> {
+  try {
+    const response = await apiClient.get('/category');
+    const payload = response.data?.data ?? response.data;
+
+    const categoriesArray = Array.isArray(payload?.data)
+      ? payload.data
+      : Array.isArray(payload?.categories)
+        ? payload.categories
+        : Array.isArray(payload)
+          ? payload
+          : [];
+
+    return categoriesArray
+      .map((category) => normalizeCategory(category))
+      .filter((category): category is Category => Boolean(category));
+  } catch (error: any) {
+    console.error('Erro ao listar categorias:', error?.response?.data || error.message);
+    throw new Error('Erro ao listar categorias');
+  }
+}
+
+export async function createCategory(payload: CreateCategoryPayload, token?: string): Promise<Category> {
+  try {
+    const response = await apiClient.post('/category', payload, {
+      headers: buildAuthHeaders(token),
+    });
+
+    const normalized = normalizeCategory(response.data?.data ?? response.data);
+
+    if (!normalized) {
+      throw new Error('Categoria inválida retornada pela API');
+    }
+
+    return normalized;
+  } catch (error: any) {
+    console.error('Erro ao criar categoria:', error?.response?.data || error.message);
+    throw new Error('Erro ao criar categoria');
+  }
+}

--- a/services/itemService.ts
+++ b/services/itemService.ts
@@ -5,6 +5,7 @@ export interface CreateItemPayload {
   description: string;
   lat: number;
   lng: number;
+  categoryId?: string | null;
   category?: string | null;
   condition?: string;
   images?: string[];
@@ -22,10 +23,23 @@ function buildAuthHeaders(token?: string) {
 
 export async function createItem(payload: CreateItemPayload, token?: string) {
   try {
-    const body: CreateItemPayload = {
-      ...payload,
-      images: payload.images && payload.images.length > 0 ? payload.images : ['https://placehold.co/600x400?text=Reuse'],
+    const body: Record<string, any> = {
+      title: payload.title,
+      description: payload.description,
+      lat: payload.lat,
+      lng: payload.lng,
+      condition: payload.condition,
+      images:
+        payload.images && payload.images.length > 0
+          ? payload.images
+          : ['https://placehold.co/600x400?text=Reuse'],
     };
+
+    if (payload.categoryId) {
+      body.categoryId = payload.categoryId;
+    } else if (payload.category) {
+      body.category = payload.category;
+    }
 
     const response = await apiClient.post('/items', body, {
       headers: buildAuthHeaders(token),


### PR DESCRIPTION
## Summary
- add a category service to list and create categories through the API
- load dynamic categories on the create item flow, allowing on-demand creation before publishing
- surface the category chips and filtering on the explore page and hide the items tab from the bottom navigation
- update item detail and list views to render category information returned by the backend

## Testing
- `npm run lint` *(fails: ESLint is not configured for this project)*

------
https://chatgpt.com/codex/tasks/task_e_690946a952a083278a6081f95cc32d23