### PR TITLE
Restore Meus Itens tab in protected layout

### DIFF
--- a/app/(protected)/_layout.tsx
+++ b/app/(protected)/_layout.tsx
@@ -33,7 +33,10 @@ export default function ProtectedTabsLayout() {
       <Tabs.Screen
         name="items"
         options={{
-          href: null,
+          title: 'Meus Itens',
+          tabBarIcon: ({ color, size }) => (
+            <MaterialIcons name="inventory" color={color} size={size} />
+          ),
         }}
       />
       <Tabs.Screen


### PR DESCRIPTION
## Summary
- restore the Meus Itens tab in the protected navigation layout
- add an inventory icon to the restored tab

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6909492bc39483279036b9b94e2d42e6